### PR TITLE
Fix a bug when attempting to use multiple constraints

### DIFF
--- a/R/gnm.R
+++ b/R/gnm.R
@@ -163,7 +163,7 @@ gnm <- function(formula, eliminate = NULL, ofInterest = NULL,
                                 return.indices = TRUE))
         if (is.character(constrain)) {
             res <- match(constrain, coefNames, 0)
-            if (res == 0 && length(constrain) == 1){
+            if (identical(res, 0) && length(constrain) == 1){
                 constrain <- match(grep(constrain, coefNames),
                                        seq_len(nParam),  0)
             }


### PR DESCRIPTION
This PR fixes a bug during the step where the `gnm()` function determines which coefficients to constrain based on the arguments to the function call. The original code askes `if(res == 0 && length(constrain) == 1)`, which seems to be testing for the situation where `constrain` is a character vector of length 1 but does not match any of the existing coefficient names. However, when two or more coefficients to constrain are specified, then the result of `res == 0` has a length greater than 1, and this causes either a warning or error (depending on the version of R, it seems?) when matched with the scalar "AND" operator `&&`. By using `identical(res, 0)` instead, we get around this issue.